### PR TITLE
Remove -U argument

### DIFF
--- a/bin/tkn
+++ b/bin/tkn
@@ -1,6 +1,8 @@
 #!/usr/bin/env ruby
 # encoding: utf-8
 
+Encoding.default_internal = "UTF-8"
+
 require 'io/console'
 require 'active_support/core_ext/string/strip'
 require 'pygments'


### PR DESCRIPTION
This was causing <tt>/usr/bin/env: ruby -U: No such file or directory</tt> for me. I'm using bash, 1.9.2, on ubuntu.
