### PR TITLE
Poor man remote control

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,10 @@ A snippet for your editor is basic to write slides quickly. The [extras folder](
 
 [Cathode](http://www.secretgeometry.com/apps/cathode/) is perfect for this thing. But because of how it draws the text it doesn't do bold faces and may not be able to render some colors or Unicode characters. YMMV.
 
+## Remote
+
+If the `WEB` env var is set to `true`, it starts a webserver on port `3000`. By visiting that page with your smartphone, you can control the presentation from there.
+Note: Web and console mode are mutual exclusive: keyboard commands get ignored when web is activated.
 
 ## Installation
 

--- a/bin/tkn
+++ b/bin/tkn
@@ -241,6 +241,45 @@ def toggle_status(status, n, total)
 end
 
 
+if ENV['WEB'] == 'true'
+  $web = true
+  $reader, $writer = IO.pipe
+
+  #
+  # --- Web Server ------------------------------------------------------
+  #
+  require 'webrick'
+
+  webserver_pid = fork do
+    server = WEBrick::HTTPServer.new :Port => 3000, :AccessLog => [[$writer, '%q']], :Logger => WEBrick::Log.new('/dev/null', Logger::FATAL)
+    server.mount_proc '/' do |req, res|
+      res.body = <<-HTML
+<html>
+  <head>
+    <title>Presentation</title>
+    <style type="text/css">
+      * { font-size: 2em; font-weight: bold; font-family: helvetica; }
+      a { color: #000; text-decoration: none; }
+      #previous { float: left; }
+      #next     { float: right; }
+      #quit     { position: absolute; bottom: 0; left: 0; font-size: .5em; }
+    </style>
+    <link rel="shortcut icon" href="data:image/x-icon;," type="image/x-icon">
+  </head>
+  <body>
+  <div id="previous"><a href="?p">&#9668;</a></div>
+  <div id="next"><a href="?n">&#9658;</a></div>
+  <div id="quit"><a href="?q" onclick="return confirm('Are you sure?')">x</a><div>
+  </body>
+</html>
+      HTML
+    end
+
+    server.start
+  end
+end
+
+
 #
 # --- Main Loop -------------------------------------------------------
 #
@@ -249,12 +288,16 @@ end
 # configure Terminal.app so that PageDown and PageUp get passed down the
 # script. Echoing is turned off while doing this.
 def read_command
-  $stdin.noecho do |noecho|
-    noecho.raw do |raw|
-      raw.getc.tap do |command|
-        # Consume PageUp or PageDown if present. No other ANSI escape sequence is
-        # supported so a blind 3.times getc is enough.
-        3.times { command << raw.getc } if command == "\e"
+  if $web
+    $reader.gets.strip
+  else
+    $stdin.noecho do |noecho|
+      noecho.raw do |raw|
+        raw.getc.tap do |command|
+          # Consume PageUp or PageDown if present. No other ANSI escape sequence is
+          # supported so a blind 3.times getc is enough.
+          3.times { command << raw.getc } if command == "\e"
+        end
       end
     end
   end
@@ -307,6 +350,7 @@ loop do
     status = toggle_status(status, n, $slides.size)
   when 'q'
     clear_slide(slide)
+    Process.kill('HUP', webserver_pid) if $web
     exit
   end
 end


### PR DESCRIPTION
Enable a web interface to control the presentation.

If the `WEB` env var is set to `true` it starts a web server on port `3000`, where it is possible to control the presentation (previous/next/quit), for instance with a smartphone.

Implementation notes: It forks a subprocess to fire up the web server and uses IPC (via `IO.pipe`) to communicate commands.
WEBrick is setup with a custom logger that only prints the query string of the requested resource and uses the writer pipe as output. The simple web page contains a set of links that are directly mapping **tkn** commands (`/?p`, `/?n`, `/?q`), so that a click on the right arrow, communicates `n` to the parent process and the next slide is rendered.
