### PR TITLE
Speed up the transition for lengthier slides

### DIFF
--- a/bin/tkn
+++ b/bin/tkn
@@ -7,6 +7,8 @@ require 'io/console'
 require 'active_support/core_ext/string/strip'
 require 'pygments'
 
+TRANSITIONS_TIME = 0.3
+MAX_CHAR_DELAY   = 0.002
 
 #
 # --- DSL -------------------------------------------------------------
@@ -287,9 +289,12 @@ loop do
   if image?(slide)
     render(slide)
   else
-    render(slide).each_char do |c|
+    output = render(slide)
+    pause  = [TRANSITIONS_TIME / output.length, MAX_CHAR_DELAY].min
+
+    output.each_char do |c|
       print c
-      sleep 0.002 # old-school touch: running cursor
+      sleep pause # old-school touch: running cursor
     end
   end
 


### PR DESCRIPTION
Sleeping 0.002s works great for shorter slides, but the transition time can become quite noticeable when there is more text – a larger code snippet or a "fancier" "diagram". This can get very annoying when you're moving back and forth between the slides and you're forced to wait quite a while.

Instead, I suggest an upper limit on how much a transition can take. If changing the slide would take more, the pause between printing each character is decreased. If not, the 0.002s pause is kept. I've set the upper slide transition limit to 0.3 because I'm a fan of faster transitions, but 0.4 and 0.5 also work fine.

If you're curious about when I'm encountering this problem, you can check [this deck](https://github.com/skanev/tkn/blob/wip-bunch-of-things/examples/vim_and_zsh.rb) – it contains a few slides that take a bit too much for a 0.002s transition.
