### PR TITLE
search_for rescues and continues

### DIFF
--- a/bin/tkn
+++ b/bin/tkn
@@ -206,13 +206,19 @@ def go_to(n)
 end
 
 def search_for(n)
-  target = prompt('Search for')
-  return n if target.length == 0
+  begin
+    target = prompt('Search for')
+    return n if target.length == 0
 
-  regexp = %r{#{target}}
-  $slides.each.with_index do |slide, i|
-    next if image?(slide)
-    n = i and break if ansi_strip(slide[:content]) =~ regexp
+    regexp = %r{#{target}}
+    $slides.each.with_index do |slide, i|
+      next if image?(slide)
+      n = i and break if ansi_strip(slide[:content]) =~ regexp
+    end
+    n
+  rescue => e
+    puts e
+    $stdin.getc
   end
   n
 end


### PR DESCRIPTION
Making a mistake with search regexp resulted in tkn bailing out.

This PR adds `begin...rescue` block to display any such error and continue as if nothing happened.
