### PR TITLE
Run console ($SHELL) inside presentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,8 @@ There is one hard-coded visual effect: Once the exact characters of a given slid
 
 * Toggle status: "s".
 
+* Run $SHELL inside presentation (console): "c"
+
 * Quit: "q".
 
 Searching accepts a regular expression. A nice trick to enable a modifier in a particular search is to use the

--- a/bin/tkn
+++ b/bin/tkn
@@ -242,6 +242,10 @@ def toggle_status(status, n, total)
   !status
 end
 
+def run_console
+  system("#{ENV['SHELL']}")
+end
+
 
 #
 # --- Main Loop -------------------------------------------------------
@@ -313,6 +317,10 @@ loop do
     n = search_for(n)
   when 's'
     status = toggle_status(status, n, $slides.size)
+  when 'c'
+    clear_slide(slide)
+    run_console
+    clear_slide(slide)
   when 'q'
     clear_slide(slide)
     exit


### PR DESCRIPTION
This PR adds keyboard command `c` which runs console (`$SHELL`) in current directory.
When the shell exits, presentation continues where it left off.

This is useful for doing a live demo of whatever was just presented on the slide.