### PR TITLE
run_editor: open $VISUAL or $EDITOR at current slide location

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,8 @@ There is one hard-coded visual effect: Once the exact characters of a given slid
 
 * Toggle status: "s".
 
+* Edit deck with $VISUAL or $EDITOR or vim. If editor supports, jump to current slide location: "v"
+
 * Quit: "q".
 
 Searching accepts a regular expression. A nice trick to enable a modifier in a particular search is to use the

--- a/bin/tkn
+++ b/bin/tkn
@@ -36,10 +36,16 @@ def section(title)
 end
 
 def slide(content, format, *args)
+  # Find out line number where this slide is defined
+  # account for code, block, center etc that insert one line
+  loc = caller.first =~ /^#{__FILE__}/ ? caller[1] : caller[0]
+  line = /[^:]+:(\d+):in/.match(loc).captures.first
+
   $slides << {
     content: content.strip_heredoc,
     format:  format,
-    args:    args
+    args:    args,
+    line:    line
   }
 end
 
@@ -242,6 +248,16 @@ def toggle_status(status, n, total)
   !status
 end
 
+def run_editor(deck,slide)
+  editor = ENV['VISUAL']
+  editor = ENV['EDITOR'] if !editor || editor.empty?
+  editor = %x(which vim).chomp if !editor || editor.empty?
+  # if no editor found, can't do much
+  return if !editor || editor.empty?
+  # Joe, nano and vi(m) support opening file at given line number
+  linenum = editor =~ /joe|nano|vi/ ? "+#{slide[:line]}" : ""
+  system("#{editor} #{linenum} #{deck}")
+end
 
 #
 # --- Main Loop -------------------------------------------------------
@@ -313,6 +329,10 @@ loop do
     n = search_for(n)
   when 's'
     status = toggle_status(status, n, $slides.size)
+  when 'v'
+    clear_slide(slide)
+    run_editor(deck,slide)
+    clear_slide(slide)
   when 'q'
     clear_slide(slide)
     exit


### PR DESCRIPTION
This PR maps keyboard shortcut `v` to open the slide deck in `$VISUAL` or `$EDITOR` (or `vim`).

If the editor is any of `vim`, `joe` or `nano` the cursor is placed at the start of the current slide. For that purpose, `slide` hash keeps record of line numbers where the slides are defined.

This is useful:
- when reviewing slides to fix typos
- during presentation to add notes etc right into the presentation
