### PR TITLE
Check the file input

### DIFF
--- a/bin/tkn
+++ b/bin/tkn
@@ -5,6 +5,7 @@ Encoding.default_internal = "UTF-8"
 
 require 'io/console'
 require 'active_support/core_ext/string/strip'
+require 'active_support/core_ext/object/blank'
 require 'pygments'
 
 TRANSITIONS_TIME = 0.3
@@ -270,6 +271,16 @@ deck   = ARGV[0]
 mtime  = nil
 slide  = nil
 status = false
+
+if deck.blank?
+  puts "Please specify the file"
+  exit 1
+end
+
+unless File.exist?(deck)
+  puts "#{deck} does not exist"
+  exit 1
+end
 
 loop do
   clear_slide(slide)


### PR DESCRIPTION
Otherwise it crashes when I run it without the first arguments:

```
$ bin/tkn

bin/tkn:277:in `mtime': no implicit conversion of nil into String (TypeError)
	from bin/tkn:277:in `block in <main>'
	from bin/tkn:274:in `loop'
	from bin/tkn:274:in `<main>'
```

(I wanted to run the tkn binary without args to see the help)